### PR TITLE
Wrong js module import

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
 	<js-module src="www/IndoorAtlas.js" name="IndoorAtlas">
 		<clobbers target="IndoorAtlas" />
 	</js-module>
-    <js-module src="www/Floorplan.js" name="FloorPlan">
+    <js-module src="www/FloorPlan.js" name="FloorPlan">
         <clobbers target="FloorPlan" />
     </js-module>
     


### PR DESCRIPTION
I got this error `Failed to install 'cordova-plugin-indooratlas':Error: ENOENT, no such file or directory '/CordovaExamples/plugins/cordova-plugin-indooratlas/www/Floorplan.js'`

The file in the `www` directory is `FloorPlan.js` instead of `Floorplan.js`
