### PR TITLE
SDK 2.9 update for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 2.0.0 - September 2019
+------------------------------
+ * IndoorAtlas SDK version 2.9 with integrated wayfinding
+ * New wayfinding API
+
 Version 1.10.0 - August 2018
 ------------------------------
 * IndoorAtlas Wayfinding SDK version 2.8: directed edge support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IndoorAtlas Cordova Plugin 1.10 with IndoorAtlas SDK 2.8
+# IndoorAtlas Cordova Plugin 2.0 with IndoorAtlas SDK 2.9
 
 [IndoorAtlas](https://www.indooratlas.com/) provides a unique Platform-as-a-Service (PaaS) solution that runs a disruptive geomagnetic positioning in its full-stack hybrid technology for accurately pinpointing a location inside a building. The IndoorAtlas SDK enables app developers to use high-accuracy indoor positioning in venues that have been fingerprinted.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-indooratlas",
-  "version": "1.10.0",
+  "version": "2.0.0",
   "description": "Cordova plugin using IndoorAtlas SDK.",
   "cordova": {
     "id": "cordova-plugin-indooratlas",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-indooratlas"
-        version="1.9.0">
+        version="2.0.0">
 
   <name>IndoorAtlas</name>
   <description>IndoorAtlas Cordova Plugin.</description>
@@ -30,15 +30,6 @@
   </js-module>
   <js-module src="www/FloorPlan.js" name="FloorPlan">
     <clobbers target="FloorPlan"/>
-  </js-module>
-  <js-module src="www/Promise.js" name="IAPromise">
-    <clobbers target="IAPromise"/>
-  </js-module>
-  <js-module src="www/RoutingLeg.js" name="RoutingLeg">
-    <clobbers target="RoutingLeg"/>
-  </js-module>
-  <js-module src="www/RoutingPoint.js" name="RoutingPoint">
-    <clobbers target="RoutingPoint"/>
   </js-module>
   <js-module src="www/CoordinateTransforms.js" name="CoordinateTransforms">
     <clobbers target="CoordinateTransforms"/>

--- a/src/android/IALocationPlugin.java
+++ b/src/android/IALocationPlugin.java
@@ -185,12 +185,20 @@ public class IALocationPlugin extends CordovaPlugin {
             } else if ("removeStatusCallback".equals(action)) {
               removeStatusCallback();
             } else if ("requestWayfindingUpdates".equals(action)) {
-                Double lat = args.getDouble(0);
-                Double lon = args.getDouble(1);
-                int floor = args.getInt(2);
-                requestWayfindingUpdates(lat, lon, floor, callbackContext);
+              double lat = args.getDouble(0);
+              double lon = args.getDouble(1);
+              int floor = args.getInt(2);
+              requestWayfindingUpdates(lat, lon, floor, callbackContext);
             } else if ("removeWayfindingUpdates".equals(action)) {
-                removeWayfindingUpdates();
+              removeWayfindingUpdates();
+            } else if ("lockFloor".equals(action)) {
+              int floorNumber = args.getInt(0);
+              lockFloor(floorNumber);
+            } else if ("unlockFloor".equals(action)) {
+              unlockFloor();
+            } else if ("lockIndoors".equals(action)) {
+              boolean locked = args.getBoolean(0);
+              lockIndoors(locked);
             }
         }
         catch(Exception ex) {
@@ -354,6 +362,33 @@ public class IALocationPlugin extends CordovaPlugin {
             @Override
             public void run() {
               mLocationManager.removeWayfindingUpdates();
+            }
+        });
+    }
+
+    private void lockFloor(final int floorNumber) {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              mLocationManager.lockFloor(floorNumber);
+            }
+        });
+    }
+
+    private void unlockFloor() {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              mLocationManager.unlockFloor();
+            }
+        });
+    }
+
+    private void lockIndoors(final boolean locked) {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              mLocationManager.lockIndoors(locked);
             }
         });
     }

--- a/src/android/indooratlas.gradle
+++ b/src/android/indooratlas.gradle
@@ -7,6 +7,5 @@ repositories {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.indooratlas.android:indooratlas-android-sdk:2.8.2@aar'
-    compile 'com.indooratlas.android:indooratlas-android-wayfinding:2.8.0@aar'
+    compile 'com.indooratlas.android:indooratlas-android-sdk:2.9.0@aar'
 }

--- a/src/android/indooratlas.gradle
+++ b/src/android/indooratlas.gradle
@@ -3,9 +3,19 @@ repositories {
     maven {
         url "https://indooratlas-ltd.bintray.com/mvn-public/"
     }
+    maven {
+        url "https://indooratlas-ltd.bintray.com/mvn-public-beta/"
+    }
+    maven {
+        url "https://indooratlas-ltd.bintray.com/mvn-internal"
+        credentials {
+            username bintrayUsername
+            password bintrayKey
+        }
+    }
 }
 
 dependencies {
     compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.indooratlas.android:indooratlas-android-sdk:2.9.0@aar'
+    compile 'com.indooratlas.android:indooratlas-android-sdk:2.9.0-dev-929@aar'
 }

--- a/www/IndoorAtlas.js
+++ b/www/IndoorAtlas.js
@@ -373,6 +373,40 @@ var IndoorAtlas = {
     exec(win, fail, "IndoorAtlas", "removeWayfindingUpdates", []);
   },
 
+  lockFloor: function (floorNumber) {
+    var win = function (success) {};
+    var fail = buildIaErrorCallback(null);
+
+    function iaIsInteger(value) {
+      // official Mozilla polyfill for Number.isInteger
+      return typeof value === 'number' &&  isFinite(value) && Math.floor(value) === value;
+    }
+
+    if (iaIsInteger(floorNumber)) {
+      exec(win, fail, "IndoorAtlas", "lockFloor", [floorNumber]);
+    } else {
+      // should use console.error, exception etc., but doing this for
+      // consistency with other methods
+      console.log("lockFloor(floorNumber) error: floorNumber must be an integer");
+    }
+  },
+
+  unlockFloor: function () {
+    var win = function (success) {};
+    var fail = buildIaErrorCallback(null);
+    exec(win, fail, "IndoorAtlas", "unlockFloor", []);
+  },
+
+  lockIndoors: function (locked) {
+    // notice that since all parameters are optional in JavaScript, we cannot
+    // avoid users calling .lockIndoors(). This is interpreted as enabling
+    // IndoorLock (instead of .lockIndoors(false)) to avoid confusion.
+    var isLocked = !!locked || locked === undefined;
+    var win = function (success) {};
+    var fail = buildIaErrorCallback(null);
+    exec(win, fail, "IndoorAtlas", "lockIndoors", [isLocked]);
+  },
+
   setDistanceFilter: function(successCallback, errorCallback, distance) {
     var win = successCallback;
     var fail = buildIaErrorCallback(errorCallback);

--- a/www/IndoorAtlas.js
+++ b/www/IndoorAtlas.js
@@ -196,7 +196,37 @@ var IndoorAtlas = {
     };
 
     var win = function(r) {
-      var region = new Region(r.regionId, r.timestamp, r.regionType, r.transitionType);
+
+      function iaFloorPlanFromObject(fp) {
+        return new FloorPlan(
+          fp.id,
+          fp.name,
+          fp.url,
+          fp.floorLevel,
+          fp.bearing,
+          fp.bitmapHeight,
+          fp.bitmapWidth,
+          fp.heightMeters,
+          fp.widthMeters,
+          fp.metersToPixels,
+          fp.pixelsToMeters,
+          fp.bottomLeft,
+          fp.center,
+          fp.topLeft,
+          fp.topRight
+        );
+      }
+
+      var floorPlan = null, venue = null;
+      if (r.floorPlan) {
+        floorPlan = iaFloorPlanFromObject(r.floorPlan);
+      }
+      if (r.venue) {
+        venue = r.venue;
+        venue.floorPlans = venue.floorPlans.map(iaFloorPlanFromObject);
+      }
+
+      var region = new Region(r.regionId, r.timestamp, r.regionType, r.transitionType, floorPlan, venue);
       if (region.transitionType == Region.TRANSITION_TYPE_ENTER) {
         onEnterRegion(region);
       }
@@ -399,64 +429,6 @@ var IndoorAtlas = {
 
   removeWayfindingUpdates: function () {
     exec(win, fail, "IndoorAtlas", "removeWayfindingUpdates", []);
-  },
-
-  fetchFloorPlanWithId: function(floorplanId, successCallback, errorCallback){
-    var win = function(p) {
-      var floorplan = new FloorPlan(
-        p.id,
-        p.name,
-        p.url,
-        p.floorLevel,
-        p.bearing,
-        p.bitmapHeight,
-        p.bitmapWidth,
-        p.heightMeters,
-        p.widthMeters,
-        p.metersToPixels,
-        p.pixelsToMeters,
-        p.bottomLeft,
-        p.center,
-        p.topLeft,
-        p.topRight
-      );
-      successCallback(floorplan);
-    };
-    var fail = function(e) {
-      var err = new PositionError(e.code, e.message);
-      if (errorCallback) {
-        errorCallback(err);
-      }
-    };
-    exec(win, fail, "IndoorAtlas", "fetchFloorplan", [floorplanId]);
-  },
-
-  coordinateToPoint: function(coords, floorplanId, successCallback, errorCallback){
-    var win = function(p) {
-      successCallback(p);
-    };
-    var fail = function(e) {
-      var err = new PositionError(e.code, e.message);
-      if (errorCallback) {
-        errorCallback(err);
-      }
-    };
-    exec(win, fail, "IndoorAtlas", "coordinateToPoint",
-    [coords.latitude, coords.longitude, floorplanId]);
-  },
-
-  pointToCoordinate: function(point, floorplanId, successCallback, errorCallback) {
-    var win = function(p) {
-      successCallback(p);
-    };
-    var fail = function(e) {
-      var err = new PositionError(e.code, e.message);
-      if (errorCallback) {
-        errorCallback(err);
-      }
-    };
-    exec(win, fail, "IndoorAtlas", "pointToCoordinate",
-    [point.x, point.y, floorplanId]);
   },
 
   setDistanceFilter: function(successCallback, errorCallback, distance) {

--- a/www/Region.js
+++ b/www/Region.js
@@ -6,8 +6,10 @@
  * @param timestamp
  * @param regionType
  * @param transitionType
+ * @param floorPlan
+ * @param venue
  */
-var Region = function(regionId, timestamp, regionType, transitionType) {
+var Region = function(regionId, timestamp, regionType, transitionType, floorPlan, venue) {
 
   // Region ID
   this.regionId = regionId || '';
@@ -20,6 +22,12 @@ var Region = function(regionId, timestamp, regionType, transitionType) {
 
   // Transition type of the region; ENTER, EXIT, UNKNOWN
   this.transitionType = transitionType || null;
+
+  // Floor plan object
+  this.floorPlan = floorPlan || null;
+
+  // Venue object
+  this.venue = venue || null;
 };
 
 Region.TRANSITION_TYPE_UNKNOWN = 0;


### PR DESCRIPTION
 * Bump version to 2.0 since this breaks the old wayfinding API which was not a separate plugin in Cordova but part of the main plugin (unlike in the native SDKs)
 * Remove (useless) JS "clobber" classes IARoutingPoint etc. route can be "just data"
 * Remove IAPromise that was just used for the wayfinding plugin
 * Remove old wayfinding plugin code
 * remove fetchFloorPlanWithId from the API
 * remove pointToCoordinate & coordinateToPoint from the API. Notice that the recommended replacements floorPlan.pointToCoordinate etc. are already available
 * populating iaRegion.floorPlan and iaRegion.venue based on the SDK 2.9 region metadata
 * Android implementation
 * very minor Java cleanup (removed some unused imports)