### PR TITLE
Missing { in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+{  
   "name": "react-native-indooratlas",
   "version": "3.4.4",
   "description": "React.Native plugin using IndoorAtlas SDK.",


### PR DESCRIPTION
In the react-native branch the leading { of the `package.json` file is missing.